### PR TITLE
Add package to conda-forge

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Get tag
+      id: tag
+      run: |
+        echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
@@ -34,4 +40,5 @@ jobs:
       env:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: |
+        poetry version ${{ env.tag }}
         poetry publish --build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  Tests:
     name: test ${{ matrix.py }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     concurrency:

--- a/README.md
+++ b/README.md
@@ -7,16 +7,12 @@ Functions for computing metrics commonly used in the field of out-of-distributio
 <img height="19px" alt="Tests" src="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml/badge.svg" />
 </a>
 
-<a href="https://pypi.org/project/ood-metrics/">
-<img height="19px" alt="PyPI version" src="https://badge.fury.io/py/ood_metrics.svg" />
+<a href="https://github.com/HakaiInstitute/ood-metrics/blob/main/LICENSE.txt">
+    <img alt="License" src="https://anaconda.org/conda-forge/ood-metrics/badges/license.svg" height="20px" />
 </a>
 
 <a href="https://anaconda.org/conda-forge/ood-metrics">
     <img alt="Version" src="https://anaconda.org/conda-forge/ood-metrics/badges/version.svg" height="20px" />
-</a>
-
-<a href="https://github.com/HakaiInstitute/ood-metrics/blob/main/LICENSE.txt">
-    <img alt="License" src="https://anaconda.org/conda-forge/ood-metrics/badges/license.svg" height="20px" />
 </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Functions for computing metrics commonly used in the field of out-of-distributio
 
 <div style="overflow: hidden; display: flex; justify-content:flex-start; gap:10px;">
 <a href="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml">
-<img height="19px" alt="tests" src="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml/badge.svg" />
+<img height="19px" alt="Tests" src="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml/badge.svg" />
 </a>
 
 <a href="https://pypi.org/project/ood-metrics/">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 Functions for computing metrics commonly used in the field of out-of-distribution (OOD) detection.
 
-[![tests](https://github.com/tayden/ood-metrics/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/tayden/ood-metrics/actions/workflows/tests.yml)
+<div style="overflow: hidden; display: flex; justify-content:flex-start; gap:10px;">
+<a href="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml">
+<img height="19px" alt="tests" src="https://github.com/tayden/ood-metrics/actions/workflows/tests.yml/badge.svg" />
+</a>
+
+<a href="https://pypi.org/project/ood-metrics/">
+<img height="19px" alt="PyPI version" src="https://badge.fury.io/py/ood_metrics.svg" />
+</a>
+</div>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Functions for computing metrics commonly used in the field of out-of-distributio
 
 ## Installation
 
+### With PIP
+
 `pip install ood-metrics`
+
+### With Conda
+
+`conda install -c conda-forge ood-metrics`
 
 ## Metrics functions
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Functions for computing metrics commonly used in the field of out-of-distributio
 <a href="https://pypi.org/project/ood-metrics/">
 <img height="19px" alt="PyPI version" src="https://badge.fury.io/py/ood_metrics.svg" />
 </a>
+
+<a href="https://anaconda.org/conda-forge/ood-metrics">
+    <img alt="Version" src="https://anaconda.org/conda-forge/ood-metrics/badges/version.svg" height="20px" />
+</a>
+
+<a href="https://github.com/HakaiInstitute/ood-metrics/blob/main/LICENSE.txt">
+    <img alt="License" src="https://anaconda.org/conda-forge/ood-metrics/badges/license.svg" height="20px" />
+</a>
 </div>
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ood-metrics"
-version = "1.1.0"
+version = "0.0.0"
 description = "Calculate common OOD detection metrics"
 authors = ["Taylor Denouden <taylordenouden@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Add ood-metrics to conda-forge to make it easier to install and handle dependency conflicts for users who use conda.

Depends on https://github.com/conda-forge/staged-recipes/pull/22141